### PR TITLE
Improve Collection rendering and browser APIs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,12 +1,13 @@
 name: Publish package
 
 on:
-  workflow_dispatch:
-    inputs:
-      version:
-        description: Version expected in packages/seniman/package.json
-        required: true
-        type: string
+  pull_request:
+    branches:
+      - main
+    paths:
+      - packages/seniman/package.json
+    types:
+      - closed
 
 permissions:
   contents: read
@@ -22,6 +23,7 @@ defaults:
 
 jobs:
   publish:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
 
     steps:
@@ -33,12 +35,16 @@ jobs:
           registry-url: https://registry.npmjs.org
           package-manager-cache: false
 
-      - name: Verify version
-        env:
-          EXPECTED_VERSION: ${{ inputs.version }}
+      - name: Verify unpublished version
         run: |
-          ACTUAL_VERSION="$(node --print "require('./package.json').version")"
-          test "$ACTUAL_VERSION" = "$EXPECTED_VERSION"
+          PACKAGE_VERSION="$(node --print "require('./package.json').version")"
+
+          if npm view "seniman@$PACKAGE_VERSION" version >/dev/null 2>&1; then
+            echo "::error::seniman@$PACKAGE_VERSION is already published"
+            exit 1
+          fi
+
+          npm view seniman version >/dev/null
 
       - run: npm ci
       - run: npm run build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,46 @@
+name: Publish package
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version expected in packages/seniman/package.json
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: npm-publish
+  cancel-in-progress: false
+
+defaults:
+  run:
+    working-directory: packages/seniman
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+
+      - name: Verify version
+        env:
+          EXPECTED_VERSION: ${{ inputs.version }}
+        run: |
+          ACTUAL_VERSION="$(node --print "require('./package.json').version")"
+          test "$ACTUAL_VERSION" = "$EXPECTED_VERSION"
+
+      - run: npm ci
+      - run: npm run build
+      - run: npm pack --dry-run
+      - run: npm publish

--- a/packages/seniman/babel/index.js
+++ b/packages/seniman/babel/index.js
@@ -384,6 +384,11 @@ function processProgram(path) {
 
     } else if (node.type == 'JSXExpressionContainer') {
 
+      // Ignore JSX comments like { /* ... */ }
+      if (node.expression && node.expression.type == 'JSXEmptyExpression') {
+        return null;
+      }
+
       let anchorExpression = process(node.expression);
 
       // if the expression is an identifier, we'll do nothing
@@ -904,6 +909,14 @@ function _buildStyleConditionValueExpression(cond) {
   }
 
   let condition = cond.condition;
+
+  if (condition.type == 'ArrowFunctionExpression' || condition.type == 'FunctionExpression') {
+    return {
+      type: 'CallExpression',
+      callee: condition,
+      arguments: []
+    };
+  }
 
   // TODO: handle style creations that are not in the static compression map
 
@@ -1520,6 +1533,13 @@ function _cleanChildren(children) {
 
     if (childNode.type == 'JSXText') {
       return childNode.value != '';
+    }
+
+    // Drop JSX comments in children: { /* ... */ }
+    if (childNode.type == 'JSXExpressionContainer' &&
+      childNode.expression &&
+      childNode.expression.type == 'JSXEmptyExpression') {
+      return false;
     }
 
     return true;

--- a/packages/seniman/babel/index.js
+++ b/packages/seniman/babel/index.js
@@ -35,6 +35,9 @@ const eventTypeIdMap = {
   'onMouseMove': 20,
   'onMouseDown': 21,
   'onMouseUp': 22,
+  'onSubmit': 23,
+  'onPaste': 24,
+  'onWheel': 25
 };
 
 const lifecycleTypeIdMap = {

--- a/packages/seniman/frontend/browser.js
+++ b/packages/seniman/frontend/browser.js
@@ -21,7 +21,14 @@
     let lastMessageTime = 0;
 
     let connectSocket = () => {
-      socket = new WebSocket(`${_window.origin.replace('http', 'ws')}?wi=${windowId}&ro=${readOffset}&vs=${_window.innerWidth}x${_window.innerHeight}&lo=${encodeURIComponent(_location.pathname + _location.search)}&vh=${_versionHash}`);
+      let viewport = _window.visualViewport;
+      let viewportWidth = Math.floor(
+        viewport ? viewport.width : _window.innerWidth
+      );
+      let viewportHeight = Math.floor(
+        viewport ? viewport.height : _window.innerHeight
+      );
+      socket = new WebSocket(`${_window.origin.replace('http', 'ws')}?wi=${windowId}&ro=${readOffset}&vs=${viewportWidth}x${viewportHeight}&lo=${encodeURIComponent(_location.pathname + _location.search)}&vh=${_versionHash}`);
       socket.binaryType = "arraybuffer";
 
       socket.onmessage = (msg) => {

--- a/packages/seniman/package-lock.json
+++ b/packages/seniman/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "seniman",
-  "version": "0.0.171",
+  "version": "0.0.172",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "seniman",
-      "version": "0.0.171",
+      "version": "0.0.172",
       "license": "ISC",
       "dependencies": {
         "fast-ratelimit": "^3.0.1",

--- a/packages/seniman/package.json
+++ b/packages/seniman/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seniman",
-  "version": "0.0.171",
+  "version": "0.0.172",
   "description": "",
   "main": "./dist/index.js",
   "type": "module",

--- a/packages/seniman/src/collection.js
+++ b/packages/seniman/src/collection.js
@@ -1,5 +1,12 @@
-import { createSequence, _createComponent } from "./window.js";
-import { onDispose, useState, useCallback } from "./state.js";
+import { createSequence, _resolveNodeResult } from "./window.js";
+import {
+  getActiveWindow,
+  onDispose,
+  useDisposableEffect,
+  useEffect,
+  useState,
+  useCallback
+} from "./state.js";
 
 export function createCollection(initialItems) {
   return new Collection(initialItems);
@@ -8,6 +15,7 @@ export function createCollection(initialItems) {
 const MODIFY_INSERT = 1;
 const MODIFY_REMOVE = 2;
 const MODIFY_SET = 3;
+const MODIFY_SPLICE = 4;
 
 class Collection {
 
@@ -19,6 +27,7 @@ class Collection {
     }
 
     this.subscribeFns = [];
+    this.spliceSubscribeFns = [];
 
     let [lengthState, setLengthState] = useState(this.items.length);
 
@@ -37,6 +46,24 @@ class Collection {
       // TODO: optimize this
       let index = this.subscribeFns.indexOf(fn);
       this.subscribeFns.splice(index, 1);
+    };
+  }
+
+  subscribeSplices(fn) {
+    this.spliceSubscribeFns.push(fn);
+
+    if (this.items.length > 0) {
+      fn({
+        type: MODIFY_SPLICE,
+        index: 0,
+        deletionCount: 0,
+        items: this.items
+      });
+    }
+
+    return () => {
+      let index = this.spliceSubscribeFns.indexOf(fn);
+      this.spliceSubscribeFns.splice(index, 1);
     };
   }
 
@@ -74,6 +101,15 @@ class Collection {
 
     this.setLengthState(this.items.length);
 
+    this.spliceSubscribeFns.forEach(fn => {
+      fn({
+        type: MODIFY_SPLICE,
+        index,
+        deletionCount,
+        items
+      });
+    });
+
     if (deletionCount > 0) {
       this.subscribeFns.forEach(fn => {
         fn({ type: MODIFY_REMOVE, index, count: deletionCount });
@@ -106,6 +142,10 @@ class Collection {
     }
 
     this.items[index] = newItem;
+
+    this.spliceSubscribeFns.forEach(fn => {
+      fn({ type: MODIFY_SET, index, item: newItem });
+    });
 
     this.subscribeFns.forEach(fn => {
       fn({ type: MODIFY_SET, index, item: newItem });
@@ -141,51 +181,147 @@ class Collection {
 
 function _CollectionMap(props) {
   let sequence = createSequence();
-  let stateSetters = [];
+  let itemRecords = [];
+  let pendingChanges = [];
+  let processingChange = false;
   let { collection, renderFn, resolveState } = props;
+  let window = getActiveWindow();
+  let processNextChangeInScope;
 
-  let unsub = collection.subscribe(
-    useCallback(change => {
-      if (change.type === MODIFY_INSERT) {
-        let { startIndex, items } = change;
-        let nodes = [];
+  function finishChange() {
+    processingChange = false;
+    processNextChangeInScope();
+  }
 
-        for (let i = 0; i < items.length; i++) {
-          let item = items[i];
+  function createItemRecord(item, onInitialValue) {
+    let record = {
+      dispose: null,
+      itemId: null,
+      published: false,
+      ready: false,
+      setter: null,
+      value: null
+    };
 
-          let stateSetterContainer = {
-            setter: null
-          };
-
-          let component = _createComponent((props) => {
-            let [state, setState] = useState(item);
-            stateSetterContainer.setter = setState;
-
-            return () => {
-              if (resolveState) {
-                return renderFn(state());
-              } else {
-                return renderFn(state);
-              }
-            };
-          });
-
-          nodes.push(component);
-          stateSetters.splice(startIndex + i, 0, stateSetterContainer);
-        }
-
-        sequence.insert(startIndex, ...nodes);
-      } else if (change.type === MODIFY_REMOVE) {
-        let { index, count } = change;
-
-        sequence.remove(index, count);
-        stateSetters.splice(index, count);
-      } else if (change.type === MODIFY_SET) {
-        let { index, item } = change;
-
-        let stateSetter = stateSetters[index].setter;
-        stateSetter(item);
+    let publish = value => {
+      if (record.published) {
+        window._attach(sequence.id, record.itemId, value);
+        return;
       }
+
+      record.value = value;
+      if (!record.ready) {
+        record.ready = true;
+        onInitialValue();
+      }
+    };
+
+    record.dispose = useDisposableEffect(() => {
+      let [state, setState] = useState(item);
+      record.setter = setState;
+
+      useEffect(() => {
+        let nodeResult = resolveState
+          ? renderFn(state())
+          : renderFn(state);
+
+        _resolveNodeResult(nodeResult, publish);
+      });
+    });
+
+    return record;
+  }
+
+  function applySplice(change) {
+    let { index, deletionCount, items } = change;
+    let removedRecords = itemRecords.slice(
+      index,
+      index + deletionCount
+    );
+
+    // Dispose the old server-side component owners first. Their browser
+    // blocks remain in the visible sequence until the replacement values
+    // below have completed their first render.
+    removedRecords.forEach(record => record.dispose());
+
+    if (items.length === 0) {
+      if (deletionCount > 0) {
+        sequence.remove(index, deletionCount);
+      }
+      itemRecords.splice(index, deletionCount);
+      finishChange();
+      return;
+    }
+
+    let readyCount = 0;
+    let insertedRecords = [];
+    let commit = () => {
+      if (deletionCount > 0) {
+        sequence.remove(index, deletionCount);
+      }
+
+      let startItemId = sequence.insert(
+        index,
+        ...insertedRecords.map(record => record.value)
+      );
+
+      for (let offset = 0; offset < insertedRecords.length; offset++) {
+        let record = insertedRecords[offset];
+        record.itemId = startItemId + offset;
+        record.published = true;
+      }
+
+      itemRecords.splice(
+        index,
+        deletionCount,
+        ...insertedRecords
+      );
+      finishChange();
+    };
+
+    let markReady = () => {
+      readyCount++;
+      if (readyCount === insertedRecords.length) {
+        commit();
+      }
+    };
+
+    insertedRecords = items.map(item =>
+      createItemRecord(item, markReady)
+    );
+  }
+
+  function processNextChange() {
+    if (processingChange || pendingChanges.length === 0) {
+      return;
+    }
+
+    processingChange = true;
+    let change = pendingChanges.shift();
+
+    if (change.type === MODIFY_SPLICE) {
+      applySplice(change);
+      return;
+    }
+
+    if (change.type === MODIFY_SET) {
+      let record = itemRecords[change.index];
+      if (!record) {
+        throw new Error(
+          `Cannot set missing Collection item ${change.index}`
+        );
+      }
+      record.setter(change.item);
+      finishChange();
+    }
+  }
+
+  processNextChangeInScope = useCallback(processNextChange);
+
+  let unsub = collection.subscribeSplices(
+    useCallback(change => {
+      pendingChanges.push(change);
+      processNextChangeInScope();
     })
   );
 

--- a/packages/seniman/src/collection.js
+++ b/packages/seniman/src/collection.js
@@ -89,7 +89,7 @@ class Collection {
   }
 
   remove(index, count) {
-    this.items.splice(index, count);
+    this.splice(index, count);
   }
 
   unshift(...items) {

--- a/packages/seniman/src/collection.js
+++ b/packages/seniman/src/collection.js
@@ -16,6 +16,8 @@ const MODIFY_INSERT = 1;
 const MODIFY_REMOVE = 2;
 const MODIFY_SET = 3;
 const MODIFY_SPLICE = 4;
+const SUBSCRIBE_CHANGES = Symbol();
+const changeSubscribers = new WeakMap();
 
 class Collection {
 
@@ -27,7 +29,7 @@ class Collection {
     }
 
     this.subscribeFns = [];
-    this.spliceSubscribeFns = [];
+    changeSubscribers.set(this, []);
 
     let [lengthState, setLengthState] = useState(this.items.length);
 
@@ -49,8 +51,9 @@ class Collection {
     };
   }
 
-  subscribeSplices(fn) {
-    this.spliceSubscribeFns.push(fn);
+  [SUBSCRIBE_CHANGES](fn) {
+    let subscribers = changeSubscribers.get(this);
+    subscribers.push(fn);
 
     if (this.items.length > 0) {
       fn({
@@ -62,8 +65,10 @@ class Collection {
     }
 
     return () => {
-      let index = this.spliceSubscribeFns.indexOf(fn);
-      this.spliceSubscribeFns.splice(index, 1);
+      let index = subscribers.indexOf(fn);
+      if (index >= 0) {
+        subscribers.splice(index, 1);
+      }
     };
   }
 
@@ -101,7 +106,7 @@ class Collection {
 
     this.setLengthState(this.items.length);
 
-    this.spliceSubscribeFns.forEach(fn => {
+    changeSubscribers.get(this).forEach(fn => {
       fn({
         type: MODIFY_SPLICE,
         index,
@@ -143,7 +148,7 @@ class Collection {
 
     this.items[index] = newItem;
 
-    this.spliceSubscribeFns.forEach(fn => {
+    changeSubscribers.get(this).forEach(fn => {
       fn({ type: MODIFY_SET, index, item: newItem });
     });
 
@@ -318,7 +323,7 @@ function _CollectionMap(props) {
 
   processNextChangeInScope = useCallback(processNextChange);
 
-  let unsub = collection.subscribeSplices(
+  let unsub = collection[SUBSCRIBE_CHANGES](
     useCallback(change => {
       pendingChanges.push(change);
       processNextChangeInScope();

--- a/packages/seniman/src/declare.js
+++ b/packages/seniman/src/declare.js
@@ -165,7 +165,19 @@ function getTemplateBuffer(rootElement, tokens) {
       tokens.push(tagName);
     }
 
-    return indexOf + 1;
+    let id = indexOf + 1;
+
+    // Tag IDs are encoded into 6 bits in the template buffer (max 63).
+    if (id > 63) {
+      throw new Error(
+        `Seniman template limit reached: this block uses more than 63 unique tokens before/including tag "${tagName}". ` +
+        `Template tag IDs are 6-bit encoded, so tag IDs above 63 will corrupt the DOM. ` +
+        `Try wrapping a bigger section into a separate block (e.g. {<div>...</div>}) or extracting a component ` +
+        `to reduce per-block token variety.`
+      );
+    }
+
+    return id;
   }
 
   function dig(siblings) {
@@ -451,6 +463,22 @@ function getElscriptBuffer(rootElement) {
   }
 
   prune();
+
+  // ELSCRIPT uses uint8 indices with 255 reserved as a sentinel.
+  if (_els.length > 255) {
+    throw new Error(
+      `Seniman template limit reached: this block needs more than 255 referenceable elements. ` +
+      `ELSCRIPT indices are 8-bit with 255 reserved, so indices above 254 will corrupt anchors/targets. ` +
+      `Try wrapping a bigger section into a separate block (e.g. {<div>...</div>}) or extracting a component.`
+    );
+  }
+
+  if (_anchors.length > 255 || _targets.length > 255) {
+    throw new Error(
+      `Seniman template limit reached: this block has too many anchors/targets for 8-bit ELSCRIPT encoding. ` +
+      `Try wrapping a bigger section into a separate block (e.g. {<div>...</div>}) or extracting a component.`
+    );
+  }
 
   return _createElScriptBuffer(_els, _anchors, _targets);
 }

--- a/packages/seniman/src/scheduler.js
+++ b/packages/seniman/src/scheduler.js
@@ -224,6 +224,13 @@ function _removeNodeSubtree(nodeId) {
   for (let i = 0; i < childrenCount; i++) {
     let childNodeId = children[i];
     let childNode = ActiveWindow.nodeMap.get(childNodeId);
+
+    // A descendant can already be expired when its own disposer and an
+    // ancestor disposer are processed in the same scheduler batch.
+    if (!childNode || childNode.updateState === NODE_EXPIRED) {
+      continue;
+    }
+
     let isEffect = childNodeId % 2 == 0;
 
     childNode.updateState = NODE_EXPIRED;
@@ -315,6 +322,13 @@ export function scheduler_calculateWorkBatch() {
     let [parentId, nodeId] = disposeList.pop();
     let node = ActiveWindow.nodeMap.get(nodeId);
 
+    // Disposal requests may overlap: deleting an ancestor expires its entire
+    // subtree, including descendants which already have explicit disposers in
+    // this batch. Only the first path owns the scheduler cleanup.
+    if (!node || node.updateState === NODE_EXPIRED) {
+      continue;
+    }
+
     _removeNodeSubtree(nodeId);
 
     node.updateState = NODE_EXPIRED;
@@ -323,9 +337,11 @@ export function scheduler_calculateWorkBatch() {
     if (parentId > 0) {
       // remove from the parent's children list
       let children = ActiveWindow.childrenListMap.get(parentId);
-      let index = children.indexOf(nodeId);
+      let index = children?.indexOf(nodeId) ?? -1;
 
-      children.splice(index, 1);
+      if (index >= 0) {
+        children.splice(index, 1);
+      }
     }
 
     schedulerOutputCommand.deletedNodeIds.push(nodeId);

--- a/packages/seniman/src/sequence.js
+++ b/packages/seniman/src/sequence.js
@@ -40,7 +40,7 @@ export class Sequence {
   }
 
   push(...items) {
-    this.insert(this.nodes.length, ...items);
+    return this.insert(this.nodes.length, ...items);
   }
 
   insert(index, ...items) {
@@ -57,6 +57,7 @@ export class Sequence {
     });
 
     this.incrementingId += items.length;
+    return startItemId;
   }
 
   reset() {

--- a/packages/seniman/src/state.js
+++ b/packages/seniman/src/state.js
@@ -249,7 +249,13 @@ function _writeInputCommand(windowId, size) {
   let { buffer, offset } = windowInputEntry;
 
   if (offset + size > buffer.length) {
-    throw new Error(`short buffer overflow, size: ${size}, offset: ${offset}, buffer length: ${buffer.length}`);
+    let nextBuffer = Buffer.allocUnsafe(
+      Math.max(buffer.length * 2, offset + size)
+    );
+
+    buffer.copy(nextBuffer, 0, 0, offset);
+    windowInputEntry.buffer = nextBuffer;
+    buffer = nextBuffer;
   }
 
   let commandBuffer = buffer.subarray(offset, offset + size);

--- a/packages/seniman/src/window.js
+++ b/packages/seniman/src/window.js
@@ -189,6 +189,7 @@ const CMD_SEQUENCE_REMOVE_ITEMS = 19;
 const pingBuffer = Buffer.from([0]);
 const scratchBuffer = Buffer.alloc(32768);
 const DELETE_BLOCK_BUFFER_SIZE = 2048;
+const MAX_BLOCK_ID = 0x7fff;
 
 let _allocatedWindowId = 1;
 
@@ -216,10 +217,14 @@ export class Window {
     this._streamInitWindow();
 
     this.latestBlockId = 10;
+    this.freeBlockIds = new Uint16Array(MAX_BLOCK_ID + 1);
+    this.freeBlockIdCount = 0;
 
     // reuse the same buffer for all block delete commands
     this.deleteBlockCommandBuffer = Buffer.alloc(DELETE_BLOCK_BUFFER_SIZE * 2);
     this.deleteBlockCount = 0;
+    this.deleteBlockFlushTimer = null;
+    this.destroyed = false;
 
     this.clientTemplateInstallationSet = new Set();
     this.clientFunctionInstallationSet = new Set();
@@ -559,6 +564,9 @@ export class Window {
   }
 
   _handleBlockCleanup(blockId) {
+    if (this.destroyed) {
+      return;
+    }
 
     // if the buffer is full, send it
     if (this.deleteBlockCount == DELETE_BLOCK_BUFFER_SIZE) {
@@ -567,6 +575,30 @@ export class Window {
 
     this.deleteBlockCommandBuffer.writeUInt16BE(blockId, this.deleteBlockCount * 2);
     this.deleteBlockCount++;
+
+    if (this.deleteBlockFlushTimer === null) {
+      this.deleteBlockFlushTimer = setTimeout(() => {
+        this.deleteBlockFlushTimer = null;
+        this.flushBlockDeleteQueue();
+      }, 0);
+    }
+  }
+
+  _recycleBlockIds(buffer, count) {
+    for (let index = 0; index < count; index++) {
+      let blockId = buffer.readUInt16BE(index * 2);
+
+      if (blockId <= 10 || blockId > MAX_BLOCK_ID) {
+        throw new Error(`Cannot recycle invalid Seniman block ID ${blockId}`);
+      }
+
+      if (this.freeBlockIdCount >= this.freeBlockIds.length) {
+        throw new Error('Seniman block ID free pool overflow');
+      }
+
+      this.freeBlockIds[this.freeBlockIdCount] = blockId;
+      this.freeBlockIdCount++;
+    }
   }
 
   emergencyFlushBlockDeleteQueue() {
@@ -582,6 +614,10 @@ export class Window {
     // the ping loop automatically flushes it
     // TODO: introduce custom delete buffer size so apps that need it can increase it to avoid this path
     setTimeout(() => {
+      if (this.destroyed) {
+        return;
+      }
+
       let buf = this._allocCommandBuffer(1 + 2 * deleteBlockCount + 2);
 
       buf.writeUInt8(CMD_REMOVE_BLOCKS, 0);
@@ -591,23 +627,36 @@ export class Window {
 
       // write the end marker
       buf.writeUInt16BE(0, 1 + 2 * deleteBlockCount);
+
+      this._recycleBlockIds(tempBuffer, deleteBlockCount);
     }, 0);
 
     this.deleteBlockCount = 0;
   }
 
   flushBlockDeleteQueue() {
-    let buf = this._allocCommandBuffer(1 + 2 * this.deleteBlockCount + 2);
+    if (this.destroyed) {
+      this.deleteBlockCount = 0;
+      return;
+    }
+
+    let deleteBlockCount = this.deleteBlockCount;
+    if (deleteBlockCount === 0) {
+      return;
+    }
+
+    let buf = this._allocCommandBuffer(1 + 2 * deleteBlockCount + 2);
 
     buf.writeUInt8(CMD_REMOVE_BLOCKS, 0);
 
     // copy over the block ids
-    this.deleteBlockCommandBuffer.copy(buf, 1, 0, this.deleteBlockCount * 2);
+    this.deleteBlockCommandBuffer.copy(buf, 1, 0, deleteBlockCount * 2);
 
     // write the end marker
-    buf.writeUInt16BE(0, 1 + 2 * this.deleteBlockCount);
+    buf.writeUInt16BE(0, 1 + 2 * deleteBlockCount);
 
     this.deleteBlockCount = 0;
+    this._recycleBlockIds(this.deleteBlockCommandBuffer, deleteBlockCount);
   }
 
   registerPong(pongBuffer) {
@@ -729,6 +778,13 @@ export class Window {
   }
 
   destroy() {
+    if (this.destroyed) {
+      return;
+    }
+    this.destroyed = true;
+
+    clearTimeout(this.deleteBlockFlushTimer);
+    this.deleteBlockFlushTimer = null;
     this.rootDisposer();
 
     // give time for the root disposer tree to complete run
@@ -740,7 +796,6 @@ export class Window {
     this.reconnectionId = 0;
 
     clearTimeout(this.postScriptTimeout);
-
     // return active pages' buffers to the pool
     this.pages.forEach(page => {
       bufferPool.returnBuffer(page.buffer);
@@ -1022,8 +1077,18 @@ export class Window {
   }
 
   _createBlockId() {
-    this.latestBlockId++;
+    if (this.freeBlockIdCount > 0) {
+      this.freeBlockIdCount--;
+      return this.freeBlockIds[this.freeBlockIdCount];
+    }
 
+    if (this.latestBlockId >= MAX_BLOCK_ID) {
+      throw new Error(
+        `Seniman block ID pool exhausted (${MAX_BLOCK_ID - 10} live or pending IDs)`
+      );
+    }
+
+    this.latestBlockId++;
     return this.latestBlockId;
   }
 

--- a/packages/seniman/src/window.js
+++ b/packages/seniman/src/window.js
@@ -42,6 +42,8 @@ const eventTypeNameMap = {
   21: 'mousedown',
   22: 'mouseup',
   23: 'submit',
+  24: 'paste',
+  25: 'wheel',
 };
 
 // TODO: use a LRU cache

--- a/packages/seniman/src/window.js
+++ b/packages/seniman/src/window.js
@@ -139,6 +139,7 @@ function WindowResizeListener(props) {
   });
 
   client.exec($c(() => {
+    let lastViewportSize = '';
     let throttle = (func, delay) => {
       let lastCall = 0;
       let timeoutId;
@@ -161,9 +162,32 @@ function WindowResizeListener(props) {
       };
     }
 
-    window.addEventListener('resize', throttle(() => {
-      $s(onResize)(window.innerWidth, window.innerHeight);
-    }, 500));
+    let reportViewportSize = throttle(() => {
+      let viewport = window.visualViewport;
+      let width = Math.floor(
+        viewport ? viewport.width : window.innerWidth
+      );
+      let height = Math.floor(
+        viewport ? viewport.height : window.innerHeight
+      );
+      let viewportSize = `${width}x${height}`;
+
+      if (viewportSize === lastViewportSize) {
+        return;
+      }
+      lastViewportSize = viewportSize;
+      $s(onResize)(width, height);
+    }, 120);
+
+    window.addEventListener('resize', reportViewportSize, {
+      passive: true
+    });
+    window.visualViewport && window.visualViewport.addEventListener(
+      'resize',
+      reportViewportSize,
+      { passive: true }
+    );
+    reportViewportSize();
   }));
 }
 

--- a/packages/seniman/src/window.js
+++ b/packages/seniman/src/window.js
@@ -1210,7 +1210,15 @@ export class Window {
           serverBindFns = untrack(() => serverBindFns());
         }
 
-        // TODO: allow unwrapped functions on $c contexts passed to eventHandlers (and onMount)
+        // Raw server functions captured by an onMount client function are
+        // shorthand for lifecycle-owned handlers.
+        if (Array.isArray(serverBindFns)) {
+          serverBindFns = serverBindFns.map((value) =>
+            typeof value === 'function'
+              ? this._allocateHandler(value)
+              : value
+          );
+        }
 
         this._streamFunctionInstallCommand(clientFnId);
         this._streamModuleInstallCommand(serverBindFns);
@@ -1329,7 +1337,15 @@ export class Window {
           serverBindFns = untrack(() => serverBindFns());
         }
 
-        // TODO: allow unwrapped functions on $c contexts passed to eventHandlers (and onMount)
+        // Raw server functions captured by a client event function are
+        // shorthand for lifecycle-owned handlers.
+        if (Array.isArray(serverBindFns)) {
+          serverBindFns = serverBindFns.map((value) =>
+            typeof value === 'function'
+              ? this._allocateHandler(value)
+              : value
+          );
+        }
 
         this._streamFunctionInstallCommand(clientFnId);
         this._streamModuleInstallCommand(serverBindFns);

--- a/packages/seniman/src/window.js
+++ b/packages/seniman/src/window.js
@@ -1543,6 +1543,27 @@ export class Window {
     }
   }
 
+  _resolveNodeResult(nodeResult, onValue) {
+    if (nodeResult && nodeResult.constructor === Component) {
+      useEffect(() => {
+        this._resolveNodeResult(
+          nodeResult.fn(nodeResult.props),
+          onValue
+        );
+      });
+      return;
+    }
+
+    if (nodeResult instanceof Function) {
+      useEffect(() => {
+        this._resolveNodeResult(nodeResult(), onValue);
+      });
+      return;
+    }
+
+    onValue(nodeResult);
+  }
+
   _createBlock3(blockTemplateId, anchors, eventHandlers, elementEffects, elementRefs, lifecycles) {
 
     let newBlockId = this._createBlockId();
@@ -1748,6 +1769,10 @@ function Component(fn, props) {
 
 export function _createComponent(componentFunction, props) {
   return new Component(componentFunction, props);
+}
+
+export function _resolveNodeResult(nodeResult, onValue) {
+  return getActiveWindow()._resolveNodeResult(nodeResult, onValue);
 }
 
 export function _createBlock(blockTemplateId, anchors, eventHandlers, styleEffects, refs, lifecycles) {


### PR DESCRIPTION
## Summary

This release improves Collection rendering, browser API coverage, lifecycle ergonomics, and runtime resilience.

- prepare Collection replacements before atomically changing visible sequences
- keep the normalized Collection change feed private while preserving the existing public API
- make `Collection.remove()` reactive, consistent with `splice()`, `set()`, and `reset()`
- grow per-window scheduler input buffers on demand
- tolerate overlapping reactive-scope disposal
- reuse released 15-bit block IDs and safely stop pending cleanup during window destruction
- support `onSubmit`, `onPaste`, and `onWheel`
- report the visual viewport at connection time and during resize
- implicitly wrap raw server functions captured by client event and `onMount` functions as lifecycle-owned handlers
- reject template encoding overflows and handle JSX comments and function-valued style conditions
- publish version-changing PRs after merge through npm trusted publishing
- bump Seniman to `0.0.172`

## Developer experience

Collection replacements no longer expose an intermediate placeholder while new components are being prepared. Existing Collection methods continue to work without requiring application changes, and `remove()` now correctly updates rendered views, subscribers, and `size()`.

Client event functions and `onMount` callbacks may capture ordinary server functions without requiring a manual `createHandler()` wrapper. Paste, wheel, and submit handlers are available through the same JSX event API as existing browser events.

`client.viewportSize()` now follows the viewport actually visible on mobile, including changes caused by a software keyboard.

Large reactive updates and long-lived views are more robust: scheduler input storage grows when needed, released block IDs are reused, and overlapping cleanup requests no longer fail the scheduler.

Compiler limits now produce actionable errors instead of malformed DOM output.

Package releases are built and published after a version-changing PR merges into `main`, without storing a long-lived npm token. The workflow rejects versions that are already present on npm before building.

## Compatibility

- The existing Collection API remains source-compatible.
- The normalized Collection change subscription is internal and does not add a new public method.
- `Collection.remove()` changes from a silent backing-array mutation to the reactive behavior its API implies.
- Existing explicit `createHandler()` usage remains valid.

## Validation

- `npm ci`
- `npm run build`
- syntax checks on the built framework, compiler, scheduler, state, Collection, and browser sources
- package creation and dry-run publication
- browser stress coverage for:
  - scheduler batches exceeding the previous 4 KiB input buffer
  - `Collection.set()`, splice replacement, and reactive `remove()`
  - absence of a public normalized-change subscription method
  - raw server callbacks captured by `onMount`
  - native wheel and paste callbacks
  - 33,000 Collection replacements
- browser verification of the tracked Trello example, including an inline task edit committed through `Collection.set()`
- `git diff --check main..HEAD`
